### PR TITLE
Add placeholder DriverHome screen

### DIFF
--- a/src/screens/DriverHome.js
+++ b/src/screens/DriverHome.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function DriverHome() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Driver Home</Text>
+      <Text>[Placeholder for assigned jobs]</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', alignItems: 'center', padding: 20 },
+  title: { fontSize: 22, fontWeight: 'bold', marginBottom: 10 },
+});


### PR DESCRIPTION
## Summary
- add a basic `DriverHome` screen so navigation works

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6843db44db108321ad2e964e56cb6994